### PR TITLE
Change ref path to TFLint GPG Key from master to Git Tag.

### DIFF
--- a/script-library/shared/settings.env
+++ b/script-library/shared/settings.env
@@ -18,7 +18,7 @@ DOTNET_VERSION_CODENAMES_REQUIRE_OLDER_LIBSSL_1="bookworm buster bullseye bionic
 DOTNET_CDN_FEED_URI="https://dotnetcli.azureedge.net"
 HELM_GPG_KEYS_URI="https://raw.githubusercontent.com/helm/helm/main/KEYS"
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
-TFLINT_GPG_KEY_URI="https://raw.githubusercontent.com/terraform-linters/tflint/master/8CE69160EB3F2FE9.key"
+TFLINT_GPG_KEY_URI="https://raw.githubusercontent.com/terraform-linters/tflint/v0.46.1/8CE69160EB3F2FE9.key"
 GO_GPG_KEY_URI="https://dl.google.com/linux/linux_signing_key.pub"
 GPG_KEY_SERVERS="keyserver hkps://keyserver.ubuntu.com
 keyserver hkps://keys.openpgp.org


### PR DESCRIPTION
The file that the TFLint GPG KEY URI is specifying has been removed from the master branch.  So it is best to reference the file via the git tag to be sure to have a successful retrieval.
